### PR TITLE
Support StartTLS for SMTP autoconfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Installation
 
 ### Apache Webserver
 
-You need an Apache webserver with PHP5 preconfigures. You can then configure your Virtual Host like this
+You need an Apache webserver with (at least) PHP 7.3 preconfigured. You can then configure your Virtual Host like this
 
 ```
 <VirtualHost *:443>

--- a/autodiscover.xml.php
+++ b/autodiscover.xml.php
@@ -16,7 +16,8 @@ $xml = str_replace("%INFO/DOMAIN%", $config['info']['domain'], $xml);
 $xml = str_replace("%TTL%", $config['ttl'], $xml);
 
 
-$xml = str_replace("%SERVER/SMTP/SSL_ON%", isOnOrOff($config['server']['smtp']['socket'] == "SSL"), $xml);
+$xml = str_replace("%SERVER/SMTP/ENCRYPTION%", str_replace("STARTTLS", "TLS", $config['server']['smtp']['socket']), $xml);
+
 $xml = str_replace("%SERVER/IMAP/SSL_ON%", isOnOrOff($config['server']['imap']['socket'] == "SSL"), $xml);
 
 $xml = str_replace("%SERVER/IMAP/DOMAIN_REQUIRED%", isOnOrOff($config['server']['domain_required']), $xml);

--- a/autodiscover.xml.php
+++ b/autodiscover.xml.php
@@ -73,7 +73,7 @@ function loadTemplate ($file) {
 
 function determineTemplateFile () {
 
-  $template = array_key_exists('template', $_GET) ? $_GET['template'] : null;
+  $template = $_GET['template'] ?? null;
   
   switch($template) {
 
@@ -93,7 +93,7 @@ function determineTemplateFile () {
 
 function getRequestEmail () {
 
-  $email = array_key_exists('email', $_GET) ? $_GET['email'] : null;
+  $email = $_GET['email'] ?? null;
   return filter_var($email, FILTER_VALIDATE_EMAIL);
 
 }

--- a/autodiscover.xml.php
+++ b/autodiscover.xml.php
@@ -56,11 +56,19 @@ function isOnOrOff ($value) {
 }
 
 function loadConfig () {
-  return json_decode(implode('', file('settings.json')), true);
+  $content = file_get_contents('settings.json');
+  if ($content === FALSE) {
+    throw new Exception('Error reading settings.json.');
+  }
+  return json_decode($content, true, 512, JSON_THROW_ON_ERROR);
 }
 
 function loadTemplate ($file) {
-  return implode("",file($file));
+  $content = file_get_contents($file);
+  if ($content === FALSE) {
+    throw new Exception('Error reading template file.');
+  }
+  return $content;
 }
 
 function determineTemplateFile () {

--- a/mail/autodiscover.xml
+++ b/mail/autodiscover.xml
@@ -150,7 +150,7 @@ If this value is true, then the SMTP server requires that email be downloaded be
   <Port>%SERVER/SMTP/PORT%</Port>
   <DomainRequired>%SERVER/SMTP/DOMAIN_REQUIRED%</DomainRequired>
   <SPA>off</SPA>
-  <SSL>%SERVER/SMTP/SSL_ON%</SSL>
+  <Encryption>%SERVER/SMTP/ENCRYPTION%</Encryption>
   <AuthRequired>on</AuthRequired>
   <UsePOPAuth>on</UsePOPAuth>
   <SMTPLast>off</SMTPLast>


### PR DESCRIPTION
Hello

I want to advertise the submission port (SMTP with STARTTLS and authentication, port 587) instead of SMTP via SSL (port 465). Reason: port 587 is the standard, port 465 is not RFC compliant.

I use the "socket" variable of "smtp" with the value "STARTTLS" for that. This is exactly the right format for "config-v1.1.xml".

Unfortunately, for "autodiscover.xml" it is not that simple: it seems that Outlook 2007 understands only the "SSL" tag. Since Outlook 2010, there is an "Encryption" tag superseding "SSL" (which can have the value "SSL" or "TLS", see also [1]). In this PR, I switch over to the "Encryption" tag completely. This means Outlook 2007 cannot understand the new format.

To remedy this for users staying with "SSL" and needing Outlook 2007 support, one could probably let the SSL tag remain as before (I can make that change if this is favored). According to the documentation in [1], the presence of "Encryption" should make "SSL" irrelevant for Outlook 2010 and later. However, I'm not sure if the presence of "Encryption" lets some schema validation fail in Outlook 2007...

Just for cross-reference, I'm using this in the context of [2].

[1] https://msdn.microsoft.com/en-us/library/cc463896(EXCHG.80).aspx
[2] https://github.com/johansmitsnl/docker-email-autodiscover/issues/2